### PR TITLE
feat: comprehensive process_photos system improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,12 @@ AI/
 Topics/
 Photostream/
 
+# Photo processing artifacts
+*.DS_Store
+Ingest/Photolog/Original/
+Ingest/Photolog/Processed/
+
+# Python artifacts
 __pycache__
 *.egg-info
+*.pyc

--- a/ai4pkm_cli.json
+++ b/ai4pkm_cli.json
@@ -12,8 +12,10 @@
     }
   },
   "photo_processing": {
-    "source_folder": "Photostream/",
-    "destination_folder": "Ingest/Photolog/Snap/"
+    "source_folder": "Ingest/Photolog/Original/",
+    "destination_folder": "Ingest/Photolog/Processed/",
+    "albums": ["iPhone Smart Album"],
+    "days": 7
   },
   "cron_jobs": [
     {

--- a/ai4pkm_cli/cli.py
+++ b/ai4pkm_cli/cli.py
@@ -390,7 +390,9 @@ class PKMApp:
                     agent_display = f" [green]\\[{agent_shortcuts.get(agent_name, agent_name)}][/green]"
                 else:
                     agent_display = f" [dim]\\[default][/dim]"
-                self.console.print(f"  {i}. {job.get('inline_prompt', 'Unknown')} - {job.get('cron', 'No schedule')}{agent_display}")
+                # Get job name from either inline_prompt or command
+                job_name = job.get('inline_prompt') or job.get('command', 'Unknown')
+                self.console.print(f"  {i}. {job_name} - {job.get('cron', 'No schedule')}{agent_display}")
         else:
             self.console.print(f"\n[dim]No cron jobs configured.[/dim]")
         

--- a/ai4pkm_cli/config.py
+++ b/ai4pkm_cli/config.py
@@ -22,8 +22,10 @@ class Config:
             }
         },
         "photo_processing": {
-            "source_folder": "Photostream/",
-            "destination_folder": "Ingest/Photolog/Snap/"
+            "source_folder": "Ingest/Photolog/Original/",
+            "destination_folder": "Ingest/Photolog/Processed/",
+            "albums": ["iPhone Smart Album"],
+            "days": 7
         },
         "cron_jobs": []
     }
@@ -107,17 +109,27 @@ class Config:
             agent = self.get_agent()
         return self.get(f'agents-config.{agent}', {})
         
-    def get_photo_processing_config(self) -> Dict[str, str]:
+    def get_photo_processing_config(self) -> Dict[str, Any]:
         """Get photo processing configuration."""
         return self.get('photo_processing', {
-            'source_folder': 'Photostream/',
-            'destination_folder': 'Ingest/Photolog/Snap/'
+            'source_folder': 'Ingest/Photolog/Original/',
+            'destination_folder': 'Ingest/Photolog/Processed/',
+            'albums': ['iPhone Smart Album'],
+            'days': 7
         })
         
     def get_photo_source_folder(self) -> str:
         """Get photo processing source folder."""
-        return self.get('photo_processing.source_folder', 'Photostream/')
+        return self.get('photo_processing.source_folder', 'Ingest/Photolog/Original/')
         
     def get_photo_destination_folder(self) -> str:
         """Get photo processing destination folder."""
-        return self.get('photo_processing.destination_folder', 'Ingest/Photolog/Snap/')
+        return self.get('photo_processing.destination_folder', 'Ingest/Photolog/Processed/')
+    
+    def get_photo_albums(self) -> list:
+        """Get photo processing album names."""
+        return self.get('photo_processing.albums', ['iPhone Smart Album'])
+    
+    def get_photo_days(self) -> int:
+        """Get number of days to look back for photos."""
+        return self.get('photo_processing.days', 7)

--- a/ai4pkm_cli/scripts/export_photos.applescript
+++ b/ai4pkm_cli/scripts/export_photos.applescript
@@ -1,7 +1,14 @@
-set albumName to "AI4PKM"
-
--- Create folder and resolve absolute path
-set destPOSIX to (do shell script "mkdir -p ./Photostream && cd ./Photostream && pwd")
+-- Get arguments from command line
+on run argv
+	if (count of argv) < 2 then
+		error "Usage: osascript export_photos.applescript <album_name> <destination_folder>"
+	end if
+	
+	set albumName to item 1 of argv
+	set destFolder to item 2 of argv
+	
+	-- Create folder and resolve absolute path
+	set destPOSIX to (do shell script "mkdir -p " & quoted form of destFolder & " && cd " & quoted form of destFolder & " && pwd")
 
 tell application "Photos"
 	
@@ -39,8 +46,13 @@ tell application "Photos"
 	-- Export new items (images only)
 	if (count of allItemsToExport) > 0 then
 		export allItemsToExport to (POSIX file destPOSIX as alias) with using originals
+		log "Exported " & (count of allItemsToExport) & " new photos from album '" & albumName & "'"
+	else
+		log "No new photos to export from album '" & albumName & "'"
 	end if
 end tell
+
+end run
 
 -- Helper function: remove extension
 on removeExtension(fileName)

--- a/ai4pkm_cli/scripts/process_photo.sh
+++ b/ai4pkm_cli/scripts/process_photo.sh
@@ -109,7 +109,7 @@ if [[ -n "$gps_lat" && -n "$gps_lon" ]]; then
 - **Map Link**: [View on Maps](https://maps.apple.com/?q=$gps_lat,$gps_lon)
 EOF
 else
-    echo "- **GPS Coordinates**: Not available" >> "$metadata_file"
+    echo "- **GPS Coordinates**: Not available" >> "$final_md"
 fi
 
 cat >> "$final_md" << EOF


### PR DESCRIPTION
- Fix process_photos job display showing as 'Unknown' in default screen
- Update photo processing configuration to use proper folder structure
  - Source: Ingest/Photolog/Original/ (from Photostream/)
  - Destination: Ingest/Photolog/Processed/ (from Snap/)
- Add configurable photo albums and days settings
- Improve process_photos.py command with better error handling and logging
- Fix script path resolution to use relative paths from package
- Make export_photos.applescript configurable with command-line arguments
- Fix variable reference bug in process_photo.sh script
- Add proper .gitignore entries for photo processing artifacts
- Add missing config methods for photo processing settings

This provides a complete, robust photo processing workflow that:
- Exports photos from configurable Photos app albums
- Processes images with EXIF metadata extraction
- Creates markdown metadata files with rich photo information
- Handles errors gracefully with proper logging
- Supports configurable source/destination folders