### PR TITLE
Fix: Prevent duplicate task processing from FSEvents and TBD Poller

### DIFF
--- a/ai4pkm_cli/watchdog/handlers/task_processor.py
+++ b/ai4pkm_cli/watchdog/handlers/task_processor.py
@@ -27,6 +27,7 @@ class TaskProcessor(BaseFileHandler):
         """
         super().__init__(logger, workspace_path)
         self.processed_cache = {}  # Track processed files to avoid duplicates
+        self.cache_lock = threading.Lock()  # Protect cache from race conditions
 
         # Get execution semaphore (separate from generation)
         from ...config import Config
@@ -73,14 +74,18 @@ class TaskProcessor(BaseFileHandler):
                 return
 
             # Check if already processed recently (avoid duplicates)
+            # Use lock to prevent race condition between FSEvents and TBD Poller
             file_mtime = os.path.getmtime(file_path)
             cache_key = f"{file_path}:{file_mtime}:TBD"
 
-            if cache_key in self.processed_cache:
-                return
+            with self.cache_lock:
+                if cache_key in self.processed_cache:
+                    # Already being processed by another thread
+                    self.logger.debug(f"Skipping duplicate processing: {os.path.basename(file_path)}")
+                    return
 
-            # Mark as processed
-            self.processed_cache[cache_key] = datetime.now()
+                # Mark as processed atomically
+                self.processed_cache[cache_key] = datetime.now()
 
             # Clean old cache entries (older than 1 hour)
             self._clean_cache()


### PR DESCRIPTION
## Problem

FSEvents and TBD Poller both detect the same file and trigger TaskProcessor simultaneously, causing a race condition.

**Evidence from logs:**
```
[17:53:29] ✅ Updated ... status=PROCESSED  # Appears TWICE
[17:53:29] ✅ Task status updated: PROCESSED  # Appears TWICE
[17:53:29] ✅ KTP execution completed  # Appears TWICE
```

**Root Cause:**
```python
# Both threads check cache at the same time
if cache_key in self.processed_cache:  # Thread 1: not there
    return                              # Thread 2: not there yet
self.processed_cache[cache_key] = ...  # Both add and continue!
```

## Solution

Add `threading.Lock` to make cache check-and-add **atomic**:

```python
with self.cache_lock:
    if cache_key in self.processed_cache:
        self.logger.debug(f"Skipping duplicate processing")
        return
    self.processed_cache[cache_key] = datetime.now()
```

## Changes

**Files Modified:**
- `ai4pkm_cli/watchdog/handlers/task_processor.py`
- `ai4pkm_cli/watchdog/handlers/task_evaluator.py`

**What Changed:**
1. Added `self.cache_lock = threading.Lock()` in `__init__`
2. Wrapped cache check in `with self.cache_lock:` block
3. Added debug log: "Skipping duplicate processing/evaluation"

## Result

- ✅ Only ONE thread can check and add to cache at a time
- ✅ Second thread sees cache entry and skips with debug log
- ✅ Both detection methods stay active (FSEvents for speed, Poller for reliability)
- ✅ No duplicate processing

## Testing

Can be verified by monitoring logs - duplicate processing messages should no longer appear.
