### PR TITLE
feat: add agent_params support and fix cron schedule validation

### DIFF
--- a/ai4pkm_cli/orchestrator/models.py
+++ b/ai4pkm_cli/orchestrator/models.py
@@ -30,6 +30,7 @@ class AgentDefinition:
     input_type: str = "new_file"
     output_path: str = ""
     output_type: str = "new_file"
+    output_optional: bool = False  # If True, no output is acceptable (auto-inferred from input_path)
     output_naming: str = "{title} - {agent}.md"
 
     # Execution
@@ -56,6 +57,9 @@ class AgentDefinition:
     file_path: Optional[Path] = None
     version: str = "1.0"
     last_updated: Optional[datetime] = None
+
+    # Agent-specific parameters from orchestrator.yaml
+    agent_params: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/ai4pkm_cli/orchestrator/task_manager.py
+++ b/ai4pkm_cli/orchestrator/task_manager.py
@@ -202,7 +202,9 @@ class TaskFileManager:
         if input_path:
             input_name = Path(input_path).stem
         else:
-            input_name = ctx.execution_id[:8]  # Fallback to execution ID
+            # For scheduled agents, use 'scheduled' with timestamp
+            timestamp = ctx.start_time.strftime('%H%M') if ctx.start_time else datetime.now().strftime('%H%M')
+            input_name = f'scheduled-{timestamp}'
 
         filename = f"{date_str} {agent.abbreviation} - {input_name}.md"
 
@@ -246,6 +248,16 @@ output: ""
 task_type: "{agent.abbreviation}"
 generation_log: "{log_link}"
 """
+
+        # Add agent_params if available
+        if agent.agent_params:
+            frontmatter += "agent_params:\n"
+            for key, value in agent.agent_params.items():
+                # Properly format YAML values
+                if isinstance(value, str):
+                    frontmatter += f'  {key}: "{value}"\n'
+                else:
+                    frontmatter += f'  {key}: {value}\n'
 
         # Add trigger data for QUEUED tasks
         if trigger_data_json:


### PR DESCRIPTION
## Summary

This PR adds support for custom agent parameters and fixes a critical bug in cron schedule validation for the orchestrator.

## Changes

### 1. Fix Cron Schedule Validation Bug
**Problem**: Scheduled events were triggering ALL agents with cron expressions, not just those whose schedule matched the current time.

**Solution**: Added proper validation in `_matches_trigger()` to check each agent's cron expression against current time using croniter, only matching when the previous run time is within the last 60 seconds.

**Files**: `ai4pkm_cli/orchestrator/agent_registry.py`

### 2. Add agent_params Support
**Feature**: Agents can now receive custom configuration properties from orchestrator.yaml.

**Implementation**:
- `agent_registry.py`: Capture `agent_params` from orchestrator.yaml nodes
- `models.py`: Add `agent_params: Dict[str, Any]` field to AgentDefinition
- `execution_manager.py`: Inject agent_params into execution prompts under "# Agent Parameters" section
- `task_manager.py`: Inject agent_params into task file YAML frontmatter

**Example Usage**:
```yaml
nodes:
  - type: agent
    name: Generate Event Summary (GES)
    cron: "0 * * * *"
    output_path: AI/Events
    agent_params:
      calendars:
        - "Primary"
        - "Work"
      time_window: "24h"
```

Agents receive these parameters in:
- Execution prompt under "# Agent Parameters" section
- Task file frontmatter under `agent_params:` property

### 3. Add output_optional Flag
**Feature**: Scheduled/manual agents (those with no input_path) now correctly infer `output_optional=True`.

**Behavior**: Allows agents that query external data sources (like GES querying Google Calendar) to complete successfully without producing output when no new data is available.

## Testing

All changes have been tested with the orchestrator running scheduled agents with custom parameters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)