### PR TITLE
Add watchdog to detect and restart dead poller threads (test)

### DIFF
--- a/ai4pkm_cli/orchestrator/poller_manager.py
+++ b/ai4pkm_cli/orchestrator/poller_manager.py
@@ -1,16 +1,22 @@
 """Poller manager for orchestrator - manages enabled pollers."""
 
+import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
 from ..logger import Logger
 
 logger = Logger()
 
+# Default watchdog check interval in seconds
+DEFAULT_WATCHDOG_INTERVAL = 60
+
 
 class PollerManager:
     """Manages poller instances based on orchestrator.yaml configuration."""
 
-    def __init__(self, vault_path: Path, config: 'Config', logger_instance: Optional[Any] = None):
+    def __init__(self, vault_path: Path, config: 'Config', logger_instance: Optional[Any] = None,
+                 watchdog_interval: int = DEFAULT_WATCHDOG_INTERVAL):
         """
         Initialize poller manager.
 
@@ -18,14 +24,21 @@ class PollerManager:
             vault_path: Path to vault root
             config: Config instance
             logger_instance: Logger instance (optional, uses module logger if None)
+            watchdog_interval: Interval in seconds for watchdog health checks (default: 60)
         """
         self.vault_path = Path(vault_path)
         self.config = config
         self.logger = logger_instance or logger
-        
+        self.watchdog_interval = watchdog_interval
+
         # Map of poller name -> poller instance
         self.pollers: Dict[str, 'BasePoller'] = {}
-        
+
+        # Watchdog thread state
+        self._watchdog_running = False
+        self._watchdog_thread: Optional[threading.Thread] = None
+        self._watchdog_shutdown_event = threading.Event()
+
         # Load and initialize enabled pollers
         self._load_pollers()
 
@@ -84,11 +97,11 @@ class PollerManager:
                 self.logger.error(f"Failed to load poller '{poller_name}': {e}", exc_info=True)
 
     def start_all(self) -> None:
-        """Start all enabled pollers."""
+        """Start all enabled pollers and the watchdog."""
         if not self.pollers:
             self.logger.info("No pollers to start")
             return
-        
+
         self.logger.info(f"Starting {len(self.pollers)} poller(s)...")
         for name, poller in self.pollers.items():
             try:
@@ -96,11 +109,17 @@ class PollerManager:
             except Exception as e:
                 self.logger.error(f"Failed to start poller '{name}': {e}", exc_info=True)
 
+        # Start watchdog to monitor poller health
+        self._start_watchdog()
+
     def stop_all(self) -> None:
-        """Stop all running pollers."""
+        """Stop all running pollers and the watchdog."""
+        # Stop watchdog first to prevent it from restarting pollers
+        self._stop_watchdog()
+
         if not self.pollers:
             return
-        
+
         self.logger.info(f"Stopping {len(self.pollers)} poller(s)...")
         for name, poller in self.pollers.items():
             try:
@@ -108,17 +127,106 @@ class PollerManager:
             except Exception as e:
                 self.logger.error(f"Failed to stop poller '{name}': {e}", exc_info=True)
 
+    def _start_watchdog(self) -> None:
+        """Start the watchdog thread to monitor poller health."""
+        if self._watchdog_running:
+            self.logger.warning("Watchdog is already running")
+            return
+
+        self._watchdog_running = True
+        self._watchdog_shutdown_event.clear()
+        self._watchdog_thread = threading.Thread(target=self._watchdog_loop, daemon=True)
+        self._watchdog_thread.start()
+        self.logger.info(f"Poller watchdog started (check interval: {self.watchdog_interval}s)")
+
+    def _stop_watchdog(self, timeout: float = 5.0) -> None:
+        """
+        Stop the watchdog thread.
+
+        Args:
+            timeout: Maximum time to wait for thread to stop
+        """
+        if not self._watchdog_running:
+            return
+
+        self.logger.info("Stopping poller watchdog...")
+        self._watchdog_running = False
+        self._watchdog_shutdown_event.set()
+
+        if self._watchdog_thread and self._watchdog_thread.is_alive():
+            self._watchdog_thread.join(timeout=timeout)
+            if self._watchdog_thread.is_alive():
+                self.logger.warning("Watchdog thread did not stop within timeout")
+            else:
+                self.logger.info("Poller watchdog stopped")
+
+    def _watchdog_loop(self) -> None:
+        """
+        Main watchdog loop that monitors poller health and restarts dead threads.
+
+        Runs periodically based on watchdog_interval, checking each poller's
+        thread status and restarting any that have died silently.
+        """
+        self.logger.info("Poller watchdog loop started")
+
+        while self._watchdog_running:
+            try:
+                self._check_poller_health()
+
+                # Wait for next check or shutdown signal
+                if self._watchdog_shutdown_event.wait(timeout=self.watchdog_interval):
+                    break
+
+            except Exception as e:
+                self.logger.error(f"Error in watchdog loop: {e}", exc_info=True)
+                # Still wait before retrying
+                if self._watchdog_shutdown_event.wait(timeout=self.watchdog_interval):
+                    break
+
+        self.logger.info("Poller watchdog loop stopped")
+
+    def _check_poller_health(self) -> None:
+        """
+        Check health of all pollers and restart any dead ones.
+
+        A poller is considered dead if:
+        - It was started (is_running returns True or should be running)
+        - But its thread is no longer alive (is_thread_alive returns False)
+        """
+        for name, poller in self.pollers.items():
+            try:
+                if not poller.is_healthy():
+                    self.logger.warning(
+                        f"Poller '{name}' thread died unexpectedly. "
+                        f"is_running={poller.is_running()}, "
+                        f"is_thread_alive={poller.is_thread_alive()}. "
+                        f"Attempting restart..."
+                    )
+                    poller.restart()
+                    self.logger.info(f"Poller '{name}' successfully restarted by watchdog")
+            except Exception as e:
+                self.logger.error(f"Failed to restart poller '{name}': {e}", exc_info=True)
+
     def get_status(self) -> Dict[str, Dict]:
         """
-        Get status of all pollers.
+        Get status of all pollers including health information.
 
         Returns:
             Dictionary mapping poller names to their status
         """
-        status = {}
+        status = {
+            '_watchdog': {
+                'running': self._watchdog_running,
+                'thread_alive': self._watchdog_thread is not None and self._watchdog_thread.is_alive(),
+                'interval': self.watchdog_interval,
+            },
+            'pollers': {}
+        }
         for name, poller in self.pollers.items():
-            status[name] = {
+            status['pollers'][name] = {
                 'running': poller.is_running(),
+                'thread_alive': poller.is_thread_alive(),
+                'healthy': poller.is_healthy(),
                 'state': poller.get_state(),
                 'target_dir': str(poller.target_dir),
                 'poll_interval': poller.poll_interval,
@@ -140,22 +248,23 @@ class PollerManager:
     def reload(self) -> None:
         """
         Reload poller configuration from config and restart pollers.
-        
-        Stops all running pollers, reloads config, and starts newly configured pollers.
+
+        Stops all running pollers (and watchdog), reloads config,
+        and starts newly configured pollers (with watchdog).
         """
         self.logger.info("Reloading poller configuration...")
-        
-        # Stop all running pollers
+
+        # Stop all running pollers and watchdog
         self.stop_all()
-        
+
         # Clear existing pollers
         self.pollers.clear()
-        
+
         # Reload pollers from config
         self._load_pollers()
-        
-        # Start all newly configured pollers
+
+        # Start all newly configured pollers and watchdog
         self.start_all()
-        
+
         self.logger.info(f"Poller reload complete: {len(self.pollers)} poller(s) loaded")
 

--- a/ai4pkm_cli/pollers/base_poller.py
+++ b/ai4pkm_cli/pollers/base_poller.py
@@ -181,29 +181,73 @@ class BasePoller(ABC):
     def _polling_loop(self) -> None:
         """Main polling loop that runs in background thread."""
         self.logger.info(f"{self.__class__.__name__} polling loop started")
-        
+
         first_run = True
-        
-        while self._running:
-            try:
-                if first_run:
-                    self.logger.info(f"{self.__class__.__name__} running initial poll immediately")
-                    first_run = False
-                self.run_once()
-                
-                if self._shutdown_event.wait(timeout=self.poll_interval):
-                    break
-                    
-            except Exception as e:
-                self.logger.error(f"Error in {self.__class__.__name__} polling loop: {e}", exc_info=True)
-                if self._shutdown_event.wait(timeout=60):
-                    break
-        
-        self.logger.info(f"{self.__class__.__name__} polling loop stopped")
+
+        try:
+            while self._running:
+                try:
+                    if first_run:
+                        self.logger.info(f"{self.__class__.__name__} running initial poll immediately")
+                        first_run = False
+                    self.run_once()
+
+                    if self._shutdown_event.wait(timeout=self.poll_interval):
+                        break
+
+                except Exception as e:
+                    self.logger.error(f"Error in {self.__class__.__name__} polling loop: {e}", exc_info=True)
+                    if self._shutdown_event.wait(timeout=60):
+                        break
+        except (KeyboardInterrupt, SystemExit):
+            self.logger.info(f"{self.__class__.__name__} received shutdown signal")
+        except BaseException as e:
+            # Catch any other fatal exceptions (C-level crashes, etc.)
+            self.logger.critical(f"{self.__class__.__name__} polling loop crashed with fatal error: {e}", exc_info=True)
+        finally:
+            self._running = False
+            self.logger.info(f"{self.__class__.__name__} polling loop stopped")
 
     def is_running(self) -> bool:
         """Check if poller is currently running."""
         return self._running
+
+    def is_thread_alive(self) -> bool:
+        """
+        Check if the polling thread is actually alive.
+
+        This is more reliable than is_running() for detecting silently crashed threads.
+        A thread can be marked as _running=True but actually be dead.
+
+        Returns:
+            True if thread exists and is alive, False otherwise
+        """
+        return self._thread is not None and self._thread.is_alive()
+
+    def is_healthy(self) -> bool:
+        """
+        Check if the poller is healthy (running and thread alive).
+
+        Returns:
+            True if poller should be running and thread is alive, False otherwise
+        """
+        # If not meant to be running, it's "healthy" in the sense that it's working as expected
+        if not self._running:
+            return True
+        # If meant to be running, thread must be alive
+        return self.is_thread_alive()
+
+    def restart(self) -> None:
+        """
+        Restart the poller.
+
+        Stops the poller if running and starts it again.
+        Used by watchdog to recover from dead threads.
+        """
+        self.logger.info(f"Restarting {self.__class__.__name__}...")
+        self.stop()
+        self.start()
+        self.logger.info(f"{self.__class__.__name__} restarted successfully")
 
     def get_state(self) -> Dict[str, Any]:
         """Get current state dictionary."""


### PR DESCRIPTION
Addresses issue #58 - poller threads can die silently without recovery.

Changes:
- BasePoller: Improved exception handling to catch BaseException and log fatal errors at CRITICAL level. Added is_thread_alive(), is_healthy(), and restart() methods for health monitoring.
- PollerManager: Added watchdog thread that periodically checks poller health (default: every 60s) and automatically restarts dead threads. Updated get_status() to include health info.