### PR TITLE
feat: add --no-session-persistence flag for Claude CLI

### DIFF
--- a/ai4pkm_cli/main/cli.py
+++ b/ai4pkm_cli/main/cli.py
@@ -106,6 +106,12 @@ def signal_handler(sig, frame):
     type=str,
     help="Path to a settings JSON file or a JSON string for Claude Code (passed as --settings to claude CLI)",
 )
+@click.option(
+    "--no-session-persistence",
+    "no_session_persistence",
+    is_flag=True,
+    help="Pass --no-session-persistence to the Claude CLI (disables session storage on disk)",
+)
 @click.pass_context
 def main(
     ctx,
@@ -124,6 +130,7 @@ def main(
     session_id,
     mcp_config,
     claude_settings,
+    no_session_persistence,
 ):
     """PKM CLI - Personal Knowledge Management framework."""
     # Set up signal handler for graceful shutdown
@@ -141,6 +148,7 @@ def main(
     ctx.obj["debug"] = debug
     ctx.obj["mcp_config"] = mcp_config
     ctx.obj["claude_settings"] = claude_settings
+    ctx.obj["no_session_persistence"] = no_session_persistence
 
     # If a subcommand was invoked, let it handle execution
     if ctx.invoked_subcommand is not None:
@@ -150,7 +158,7 @@ def main(
     if orchestrator_status:
         show_orchestrator_status(working_dir=working_dir, config_file=config_file)
     elif orchestrator:
-        run_orchestrator_daemon(debug=debug, working_dir=working_dir, config_file=config_file, mcp_config=mcp_config, claude_settings=claude_settings)
+        run_orchestrator_daemon(debug=debug, working_dir=working_dir, config_file=config_file, mcp_config=mcp_config, claude_settings=claude_settings, no_session_persistence=no_session_persistence)
     elif prompt_text:
         execute_prompt_with_session(
             prompt=prompt_text,
@@ -162,7 +170,8 @@ def main(
             append_system_prompt=append_system_prompt,
             append_system_prompt_file=append_system_prompt_file,
             mcp_config=mcp_config,
-            claude_settings=claude_settings
+            claude_settings=claude_settings,
+            no_session_persistence=no_session_persistence
         )
     elif list_agents:
         list_agents_handler()

--- a/ai4pkm_cli/main/orchestrator.py
+++ b/ai4pkm_cli/main/orchestrator.py
@@ -12,7 +12,7 @@ from ..logger import Logger
 logger = Logger(console_output=True)
 
 
-def run_orchestrator_daemon(vault_path: Path = None, debug: bool = False, working_dir: str = None, config_file: Path = None, mcp_config: tuple = None, claude_settings: str = None):
+def run_orchestrator_daemon(vault_path: Path = None, debug: bool = False, working_dir: str = None, config_file: Path = None, mcp_config: tuple = None, claude_settings: str = None, no_session_persistence: bool = False):
     """
     Run orchestrator in daemon mode.
 
@@ -46,7 +46,8 @@ def run_orchestrator_daemon(vault_path: Path = None, debug: bool = False, workin
         config=config,
         working_dir=Path(working_dir) if working_dir else None,
         mcp_config=mcp_config,
-        claude_settings=claude_settings
+        claude_settings=claude_settings,
+        no_session_persistence=no_session_persistence
     )
 
     # Setup signal handlers
@@ -151,7 +152,8 @@ def execute_prompt_with_session(
     working_dir: str = None,
     config_file: Path = None,
     mcp_config: tuple = None,
-    claude_settings: str = None
+    claude_settings: str = None,
+    no_session_persistence: bool = False
 ):
     """
     Execute a one-time prompt with Claude agent and optional session ID.
@@ -188,9 +190,10 @@ def execute_prompt_with_session(
         config=config,
         working_dir=Path(working_dir) if working_dir else None,
         mcp_config=mcp_config,
-        claude_settings=claude_settings
+        claude_settings=claude_settings,
+        no_session_persistence=no_session_persistence
     )
-    
+
     # Execute prompt
     start_time = time.time()
     ctx = orch.execute_prompt_with_session(

--- a/ai4pkm_cli/main/trigger.py
+++ b/ai4pkm_cli/main/trigger.py
@@ -27,9 +27,16 @@ from .trigger_agent import trigger_orchestrator_agent
     type=str,
     help="Path to a settings JSON file or a JSON string for Claude Code (passed as --settings to claude CLI)",
 )
+@click.option(
+    "--no-session-persistence",
+    "no_session_persistence",
+    is_flag=True,
+    default=None,
+    help="Pass --no-session-persistence to the Claude CLI (disables session storage on disk)",
+)
 @click.option("--file", "input_file", default=None, help="Input file path to pass to the agent (relative to vault root).")
 @click.pass_context
-def trigger_cli(ctx, agent, config_file, mcp_config, claude_settings, input_file):
+def trigger_cli(ctx, agent, config_file, mcp_config, claude_settings, no_session_persistence, input_file):
     """Trigger an orchestrator agent.
 
     If AGENT abbreviation is provided, triggers that agent directly.
@@ -47,5 +54,8 @@ def trigger_cli(ctx, agent, config_file, mcp_config, claude_settings, input_file
     combined_mcp_config = parent_mcp_config + mcp_config if mcp_config else parent_mcp_config
     # Use local --claude-settings if provided, otherwise fall back to parent context
     effective_claude_settings = claude_settings or (ctx.obj.get("claude_settings") if ctx.obj else None)
-    trigger_orchestrator_agent(abbreviation=agent, config_file=effective_config_file, working_dir=working_dir, mcp_config=combined_mcp_config, claude_settings=effective_claude_settings, input_file=input_file)
+    # Use local --no-session-persistence if provided, otherwise fall back to parent context
+    parent_nsp = ctx.obj.get("no_session_persistence") if ctx.obj else False
+    effective_no_session_persistence = no_session_persistence if no_session_persistence is not None else bool(parent_nsp)
+    trigger_orchestrator_agent(abbreviation=agent, config_file=effective_config_file, working_dir=working_dir, mcp_config=combined_mcp_config, claude_settings=effective_claude_settings, input_file=input_file, no_session_persistence=effective_no_session_persistence)
 

--- a/ai4pkm_cli/main/trigger_agent.py
+++ b/ai4pkm_cli/main/trigger_agent.py
@@ -10,7 +10,7 @@ from ..orchestrator.core import Orchestrator
 
 logger = Logger(console_output=True)
 
-def trigger_orchestrator_agent(abbreviation=None, config_file=None, working_dir=None, mcp_config=None, claude_settings=None, input_file=None):
+def trigger_orchestrator_agent(abbreviation=None, config_file=None, working_dir=None, mcp_config=None, claude_settings=None, input_file=None, no_session_persistence=False):
     """Trigger an orchestrator agent or poller interactively.
 
     Args:
@@ -20,6 +20,7 @@ def trigger_orchestrator_agent(abbreviation=None, config_file=None, working_dir=
         mcp_config: Optional tuple of MCP config JSON files or strings
         claude_settings: Optional path or JSON string for Claude --settings flag
         input_file: Optional input file path to pass to the agent
+        no_session_persistence: If True, pass --no-session-persistence to Claude CLI
     """
     try:
         config = Config(config_file=config_file)
@@ -30,7 +31,8 @@ def trigger_orchestrator_agent(abbreviation=None, config_file=None, working_dir=
             config=config,
             working_dir=Path(working_dir) if working_dir else None,
             mcp_config=mcp_config,
-            claude_settings=claude_settings
+            claude_settings=claude_settings,
+            no_session_persistence=no_session_persistence
         )
 
         agents_list = [agent for agent in orch.agent_registry.agents.values()]

--- a/ai4pkm_cli/orchestrator/core.py
+++ b/ai4pkm_cli/orchestrator/core.py
@@ -35,6 +35,7 @@ class Orchestrator:
         config: Optional['Config'] = None,
         mcp_config: Optional[tuple] = None,
         claude_settings: Optional[str] = None,
+        no_session_persistence: bool = False,
     ):
         """
         Initialize orchestrator.
@@ -48,6 +49,7 @@ class Orchestrator:
             config: Config instance (will create default if None)
             mcp_config: Optional tuple of MCP config JSON files or strings
             claude_settings: Optional path or JSON string for Claude --settings flag
+            no_session_persistence: If True, pass --no-session-persistence to Claude CLI
         """
         from ..config import Config
         from datetime import datetime
@@ -56,6 +58,7 @@ class Orchestrator:
         self.config = config or Config()
         self.mcp_config = mcp_config
         self.claude_settings = claude_settings
+        self.no_session_persistence = no_session_persistence
 
         # Use config values if not explicitly provided
         if agents_dir is None:
@@ -79,7 +82,8 @@ class Orchestrator:
             orchestrator_settings=self.agent_registry.orchestrator_settings,
             working_dir=working_dir,
             mcp_config=mcp_config,
-            claude_settings=claude_settings
+            claude_settings=claude_settings,
+            no_session_persistence=no_session_persistence
         )
         # Get file_extensions from orchestrator_settings (default to ['.md'] if not specified)
         file_extensions = self.agent_registry.orchestrator_settings.get('file_extensions', ['.md'])

--- a/ai4pkm_cli/orchestrator/execution_manager.py
+++ b/ai4pkm_cli/orchestrator/execution_manager.py
@@ -30,7 +30,7 @@ class ExecutionManager:
     Each agent can specify max_parallel limit.
     """
 
-    def __init__(self, vault_path: Path, max_concurrent: int = 3, config: Optional['Config'] = None, orchestrator_settings: Optional[dict] = None, working_dir: Optional[Path] = None, mcp_config: Optional[tuple] = None, claude_settings: Optional[str] = None):
+    def __init__(self, vault_path: Path, max_concurrent: int = 3, config: Optional['Config'] = None, orchestrator_settings: Optional[dict] = None, working_dir: Optional[Path] = None, mcp_config: Optional[tuple] = None, claude_settings: Optional[str] = None, no_session_persistence: bool = False):
         """
         Initialize execution manager.
 
@@ -42,6 +42,7 @@ class ExecutionManager:
             working_dir: Working directory for agent subprocess execution (defaults to vault_path)
             mcp_config: Optional tuple of MCP config JSON files or strings
             claude_settings: Optional path or JSON string for Claude --settings flag
+            no_session_persistence: If True, pass --no-session-persistence to Claude CLI
         """
         from ..config import Config
 
@@ -52,6 +53,7 @@ class ExecutionManager:
         self.orchestrator_settings = orchestrator_settings or {}
         self.mcp_config = mcp_config
         self.claude_settings = claude_settings
+        self.no_session_persistence = no_session_persistence
 
         # Instance-level state (no global state)
         self._running_count = 0
@@ -324,6 +326,8 @@ class ExecutionManager:
         
         # Build command with optional session ID (prompt will be passed via stdin)
         cmd = ['claude', '--permission-mode', 'bypassPermissions', '--print']
+        if self.no_session_persistence:
+            cmd.append('--no-session-persistence')
         
         if ctx.system_prompt_file:
             cmd.extend(['--system-prompt-file', str(ctx.system_prompt_file)])
@@ -367,7 +371,10 @@ class ExecutionManager:
                 logger.info(f"Session {ctx.session_id} already exists, resuming...")
                 # Clear previous error
                 ctx.error_message = None
-                cmd_resume = ['claude', '--permission-mode', 'bypassPermissions', '--print', '--resume', ctx.session_id]
+                cmd_resume = ['claude', '--permission-mode', 'bypassPermissions', '--print']
+                if self.no_session_persistence:
+                    cmd_resume.append('--no-session-persistence')
+                cmd_resume.extend(['--resume', ctx.session_id])
                 if ctx.system_prompt_file:
                     cmd_resume.extend(['--system-prompt-file', str(ctx.system_prompt_file)])
                 # Add system prompt to resume command


### PR DESCRIPTION
## Summary
- Adds an opt-in `--no-session-persistence` flag on the ai4pkm CLI (main group and `trigger` subcommand) that passes `--no-session-persistence` through to every `claude` subprocess.
- Threaded the new parameter through `run_orchestrator_daemon`, `execute_prompt_with_session`, `trigger_orchestrator_agent`, `Orchestrator`, and `ExecutionManager`, mirroring the existing `--claude-settings` plumbing.
- Both Claude invocation sites in `ExecutionManager` (initial run and `--resume` retry) only append the flag when set, so default behavior is unchanged.

## Test plan
- [ ] `ai4pkm --no-session-persistence -o` starts the daemon and spawned Claude commands include `--no-session-persistence`.
- [ ] `ai4pkm --no-session-persistence -p "hello"` one-time prompt passes the flag.
- [ ] `ai4pkm trigger --no-session-persistence <AGENT>` passes the flag; `ai4pkm --no-session-persistence trigger <AGENT>` also works via parent context.
- [ ] Without the flag, existing behavior is unchanged (no `--no-session-persistence` in the spawned `claude` argv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)