### PR TITLE
feat: add gobi template for gobi-desktop-vault

### DIFF
--- a/ai4pkm_cli/main/template.py
+++ b/ai4pkm_cli/main/template.py
@@ -28,6 +28,12 @@ TEMPLATE_REGISTRY = {
         "vault_folder": ".",
         "source_type": "git",
     },
+    "gobi-desktop": {
+        "repo": "gpminsuk/gobi-desktop-vault",
+        "description": "Gobi desktop vault",
+        "vault_folder": ".",
+        "source_type": "git",
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- Adds `gobi` entry to `TEMPLATE_REGISTRY` pointing at `gpminsuk/gobi-desktop-vault` via the git-clone source type.

## Test plan
- [ ] Run the CLI with the new `gobi` template and verify the vault clones into the expected folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)